### PR TITLE
fix(arduino): skip duplicate -T esp32.rom.libc-funcs.ld for esp32u variant

### DIFF
--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -328,7 +328,10 @@ if flag_custom_sdkconfig:
     env.Replace(BUILD_UNFLAGS=new_build_unflags)
 
     # add linker script esp32.rom.libc-funcs.ld for esp32 when PSRAM is NOT configured
-    if mcu == "esp32" and not has_psram_config():
+    # The esp32u (solo1/unicore) variant's pioarduino-build.py already adds this
+    # script, so appending it again here causes ld to abort with
+    # "linker script file 'esp32.rom.libc-funcs.ld' appears multiple times".
+    if mcu == "esp32" and chip_variant != "esp32u" and not has_psram_config():
         env.Append(LINKFLAGS=["-T", "esp32.rom.libc-funcs.ld"])
 
 

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -328,9 +328,8 @@ if flag_custom_sdkconfig:
     env.Replace(BUILD_UNFLAGS=new_build_unflags)
 
     # add linker script esp32.rom.libc-funcs.ld for esp32 when PSRAM is NOT configured
-    # The esp32u (solo1/unicore) variant's pioarduino-build.py already adds this
-    # script, so appending it again here causes ld to abort with
-    # "linker script file 'esp32.rom.libc-funcs.ld' appears multiple times".
+    # The esp32u (solo1/unicore) variant's pioarduino-build.py already handles this,
+    # so only add for non-unicore esp32 when PSRAM is not configured
     if mcu == "esp32" and chip_variant != "esp32u" and not has_psram_config():
         env.Append(LINKFLAGS=["-T", "esp32.rom.libc-funcs.ld"])
 


### PR DESCRIPTION
### Problem

Building any board with `chip_variant = esp32u` (e.g. ESP32-SOLO1) and PSRAM
disabled fails at the link step with:

```
ld: error: linker script file 'esp32.rom.libc-funcs.ld' appears multiple times
collect2: error: ld returned 1 exit status
```

Reproduces on Tasmota's `tasmota32solo1-safeboot` env using
`platform-espressif32 2026.05.50`.

### Root cause

`esp32.rom.libc-funcs.ld` is added to `LINKFLAGS` twice:

1. `framework-arduinoespressif32/tools/esp32-arduino-libs/esp32u/pioarduino-build.py`
   already passes `-T esp32.rom.libc-funcs.ld` for the `esp32u` variant.
2. `builder/frameworks/arduino.py` then appends the same `-T` for any
   `mcu == "esp32"` build without PSRAM.

Both `framework-arduinoespressif32/.../esp32u/ld/` and
`framework-espidf/components/esp_rom/esp32/ld/` are on the linker search
path and contain that script, so the second `-T` resolves to a different
physical file and `ld` aborts.

The default `esp32` variant's `pioarduino-build.py` does *not* include
the script, so the fallback in `arduino.py` is still required there —
it just must not fire for `esp32u`.

### Fix

Skip the append when `chip_variant == "esp32u"`, since that variant
already provides the script.

### Test

Built `tasmota32solo1-safeboot` (Tasmota repo, platform 2026.05.50)
with the patch applied — link step now succeeds.
